### PR TITLE
Add direct deps to fix vulns.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,35 @@
     </developer>
   </developers>
 
+  <dependencies>
+    <!-- override transitive deps to fix vulns -->
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-all</artifactId>
+      <version>2.4.8</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <version>1.9.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mindrot</groupId>
+      <artifactId>jbcrypt</artifactId>
+      <version>0.4</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>3.2.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>4.3.13.RELEASE</version>
+    </dependency>
+  </dependencies>
+
   <build>
     <resources>
       <resource>


### PR DESCRIPTION
Fixes some high risk and medium risk vulnerabilities included through transitive libraries. Some vulnerabilities are still present because there aren't any fixed versions but it should be acceptable as there aren't any code paths that lead to those vulnerable methods.